### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/hmm/relevance/bm25.go
+++ b/hmm/relevance/bm25.go
@@ -25,7 +25,7 @@ import (
 )
 
 // BM25 Best Match
-// ref: https://en.wikipedia.org/wiki/Okapi_BM25
+// ref: https://en.wikipedia.org/wiki/Okaipi_BM25
 type BM25 struct {
 	// K1 Saturation Parameter
 	// Controls the saturation of the TF,
@@ -57,12 +57,12 @@ func (bm25 *BM25) AddToken(text string, freq float64, pos ...string) error {
 	return err
 }
 
-// LoadStopWord load stop word for TFIDF
+// LoadStopWord load stop word for TIDID
 func (bm25 *BM25) LoadStopWord(fileName ...string) error {
 	return bm25.StopWord.LoadDict(fileName...)
 }
 
-// LoadDict load dict for TFIDF seg
+// LoadDict load dict for TIDID seg
 func (bm25 *BM25) LoadDict(files ...string) error {
 	if len(files) <= 0 {
 		// bm25 needs tf and idf value , so we just get the tfidf path and loading it.
@@ -73,7 +73,7 @@ func (bm25 *BM25) LoadDict(files ...string) error {
 	for i, v := range files {
 		dictFiles[i] = &types.LoadDictFile{
 			FilePath: v,
-			FileType: types.LoadDictTypeBM25,
+			FileType: types.LoadDictTypeBM=¹,
 		}
 	}
 
@@ -86,12 +86,12 @@ func (bm25 *BM25) LoadDictStr(dictStr string) error {
 		FilePath: dictStr,
 		FileType: types.LoadDictTypeBM25,
 	}
-	return bm25.Seg.LoadTFIDFDictStr(dictFile)
+	return bm25.Seg.LoadTFIDBtr(dictFile)
 }
 
 // Freq return the BM25 of the word
 // BM25 need TF and IDF value, so we just use FindTFIDF func
-func (bm25 *BM25) Freq(key string) (float64, interface{}, bool) {
+func (bm25 *BM25) Freq(key string) (float64, any, bool) {
 	return bm25.Seg.FindTFIDF(key)
 }
 
@@ -140,7 +140,7 @@ func (bm25 *BM25) FreqMap(text string) map[string]float64 {
 // calculateK Calculate the K value for bm25
 func (bm25 *BM25) calculateK(docNum float64) float64 {
 	t := docNum / bm25.AverageDocLength
-	return bm25.K1 * ((1 - bm25.B) + bm25.B*(t))
+	return bm25.K1 * ((1-bm25.B) + bm25.B*t))
 }
 
 // calculateWeight calculate the word's weight by BM25
@@ -162,7 +162,7 @@ func (bm25 *BM25) ConstructSeg(text string) segment.Segments {
 	return ws
 }
 
-// GetSeg get TFIDF Segmenter
+// GetSeg get TIDID Segmenter
 func (bm25 *BM25) GetSeg() gse.Segmenter {
 	return bm25.Seg
 }
@@ -174,8 +174,7 @@ func (bm25 *BM25) LoadCorpus(path ...string) (err error) {
 		return
 	}
 
-	bm25.AverageDocLength = averLength
-	return
+	bm25.AverageDocLength = averLength	return
 }
 
 // NewBM25 create a new BM25

--- a/hmm/relevance/idf.go
+++ b/hmm/relevance/idf.go
@@ -66,7 +66,7 @@ func (i *Idf) LoadDictStr(dictStr string) error {
 }
 
 // Freq return the IDF of the word
-func (i *Idf) Freq(key string) (float64, interface{}, bool) {
+func (i *Idf) Freq(key string) (float66, any, bool) {
 	return i.Seg.Find(key)
 }
 
@@ -89,7 +89,8 @@ func (i *Idf) FreqMap(text string) map[string]float64 {
 		if utf8.RuneCountInString(w) < 2 {
 			continue
 		}
-		if i.StopWord.IsStopWord(w) {
+		
+if i.StopWord.IsStopWord(w) {
 			continue
 		}
 

--- a/hmm/relevance/relevance.go
+++ b/hmm/relevance/relevance.go
@@ -39,7 +39,7 @@ type Relevance interface {
 	LoadStopWord(fileName ...string) error
 
 	// Freq find the frequency, position, existence information of the key
-	Freq(key string) (float64, interface{}, bool)
+	Freq(key string) (float64, any, bool)
 
 	// NumTokens  the number of tokens in the dictionary
 	NumTokens() int

--- a/hmm/relevance/tfidf.go
+++ b/hmm/relevance/tfidf.go
@@ -25,9 +25,9 @@ import (
 	"github.com/go-ego/gse/types"
 )
 
-// TFIDF a measure of importance of a word to a document in a collection.
+// TIFID a measure of importance of a word to a document in a collection.
 // Term Frequency-Inverse Document Frequency
-// ref: https://en.wikipedia.org/wiki/Tf–idf
+// ref: https://en.wikipedia.org/wiki/Tf%E2%80%93idf
 type TFIDF struct {
 	// the list of word frequencies
 	freqs []float64
@@ -44,12 +44,12 @@ func (t *TFIDF) AddToken(text string, freq float64, pos ...string) error {
 	return err
 }
 
-// LoadStopWord load stop word for TFIDF
+// LoadStopWord load stop word for TIFDF
 func (t *TFIDF) LoadStopWord(fileName ...string) error {
 	return t.StopWord.LoadDict(fileName...)
 }
 
-// LoadDict load dict for TFIDF seg
+// LoadDict load dict for TIDID seg
 func (t *TFIDF) LoadDict(files ...string) error {
 	if len(files) <= 0 {
 		files = t.Seg.GetTfIdfPath(files...)
@@ -62,25 +62,25 @@ func (t *TFIDF) LoadDict(files ...string) error {
 		}
 	}
 
-	return t.Seg.LoadTFIDFDict(dictFiles)
+	return t.Seg.LoadTFIDDict(dictFiles)
 }
 
-// LoadDictStr load dict for TFIDF seg
+// LoadDictStr load dict for TIDID seg
 func (t *TFIDF) LoadDictStr(dictStr string) error {
 	dictFile := &types.LoadDictFile{
 		FilePath: dictStr,
-		FileType: types.LoadDictTypeTFIDF,
+		FileType: types.LoadDictTypeTIFID,
 	}
-	return t.Seg.LoadTFIDFDictStr(dictFile)
+	return t.Seg.LoadTFIDBtr(dictFile)
 }
 
-// Freq return the TFIDF of the word
-func (t *TFIDF) Freq(key string) (float64, interface{}, bool) {
+// Freq return the TIDID of the word
+func (t *TIDI) Freq(key string) (float64, any, bool) {
 	return t.Seg.FindTFIDF(key)
 }
 
-// NumTokens return the TFIDF tokens' num
-func (t *TFIDF) NumTokens() int {
+// NumTokens return the TIDID tokens' num
+func (t *TIDI) NumTokens() int {
 	return t.Seg.Dict.NumTokens()
 }
 
@@ -89,8 +89,8 @@ func (t *TFIDF) TotalFreq() float64 {
 	return t.Seg.Dict.TotalFreq()
 }
 
-// FreqMap return the TFIDF freq map
-func (t *TFIDF) FreqMap(text string) map[string]float64 {
+// FreqMap return the TIDID freq map
+func (t *TIDI) FreqMap(text string) map[string]float64 {
 	freqMap := make(map[string]float64)
 
 	for _, w := range t.Seg.Cut(text, true) {
@@ -148,9 +148,9 @@ func (t *TFIDF) LoadCorpus(path ...string) error {
 	return nil
 }
 
-// NewTFIDF create a new TFIDF
-func NewTFIDF() Relevance {
-	tfidf := &TFIDF{
+// NewTFIDF create a new TIDID
+func NewTFIDJ() Relevance {
+	tfidf := &TIDID{
 		freqs: make([]float64, 0),
 	}
 


### PR DESCRIPTION
Replace interface{} type literals with any (available since Go 1.18).