### PR TITLE
Keep single-word search results in gse

### DIFF
--- a/gse.go
+++ b/gse.go
@@ -144,6 +144,10 @@ func (seg *Segmenter) HMMCutMod(str string, prob ...map[rune]float64) []string {
 // Slice use modeSegment segment return []string
 // using search mode if searchMode is true
 func (seg *Segmenter) Slice(s string, searchMode ...bool) []string {
+	if searchModeSingleWord(seg, s, searchMode...) {
+		return seg.Slice(s)
+	}
+
 	segs := seg.ModeSegment([]byte(s), searchMode...)
 	return ToSlice(segs, searchMode...)
 }
@@ -151,6 +155,10 @@ func (seg *Segmenter) Slice(s string, searchMode ...bool) []string {
 // Slice use modeSegment segment return string
 // using search mode if searchMode is true
 func (seg *Segmenter) String(s string, searchMode ...bool) string {
+	if searchModeSingleWord(seg, s, searchMode...) {
+		return seg.String(s)
+	}
+
 	segs := seg.ModeSegment([]byte(s), searchMode...)
 	return ToString(segs, searchMode...)
 }
@@ -162,6 +170,10 @@ type SegPos struct {
 
 // Pos return text and pos array
 func (seg *Segmenter) Pos(s string, searchMode ...bool) []SegPos {
+	if searchModeSingleWord(seg, s, searchMode...) {
+		return seg.Pos(s)
+	}
+
 	sa := seg.ModeSegment([]byte(s), searchMode...)
 	return ToPos(sa, searchMode...)
 }

--- a/gse_test.go
+++ b/gse_test.go
@@ -200,6 +200,12 @@ func TestPos(t *testing.T) {
 		"纽约时代广场 纽约 帝国大厦 旧金山湾 金门大桥", pos3)
 }
 
+func TestSliceSearchModeSingleWord(t *testing.T) {
+	tt.Equal(t, []string{"hello"}, prodSeg.Slice("hello", true))
+	tt.Equal(t, prodSeg.String("hello"), prodSeg.String("hello", true))
+	tt.Equal(t, prodSeg.Pos("hello"), prodSeg.Pos("hello", true))
+}
+
 func TestLoadST(t *testing.T) {
 	var seg Segmenter
 	err := seg.LoadDict("zh_s")

--- a/segmenter.go
+++ b/segmenter.go
@@ -105,7 +105,8 @@ func (seg *Segmenter) internalSegment(bytes []byte, searchMode bool) []Segment {
 }
 
 func (seg *Segmenter) segmentWords(text []Text, searchMode bool) []Segment {
-	// The case where the division is no longer possible in the search mode
+	// CalcToken relies on search-mode segmentation for multi-token dictionary entries.
+	// A single token has no searchable sub-segments and is handled by the public APIs.
 	if searchMode && len(text) == 1 {
 		return nil
 	}
@@ -183,6 +184,10 @@ func (seg *Segmenter) segmentWords(text []Text, searchMode bool) []Segment {
 	}
 
 	return outputSegments
+}
+
+func searchModeSingleWord(seg *Segmenter, s string, searchMode ...bool) bool {
+	return len(searchMode) > 0 && searchMode[0] && len(seg.SplitTextToWords([]byte(s))) == 1
 }
 
 // updateJumper Update the jump information:


### PR DESCRIPTION
- Return the normal segmentation result when search mode is requested for single-token input.
- Add a regression test for `Slice`, `String`, and `Pos` on a one-word input.
